### PR TITLE
docs/design: add Figma + UML exports, literature review, and survey PDFsDocs/design assets v1

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.pdf filter=lfs diff=lfs merge=lfs -text

--- a/design/diagrams/exports/UML_Diagram.pdf
+++ b/design/diagrams/exports/UML_Diagram.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:320c184a6ce75bbece7621edaea306b82d6575fd8d41419550b4526fea01589d
+size 407821

--- a/design/figma/exports/Figma_design.pdf
+++ b/design/figma/exports/Figma_design.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6ba9a52351fb32f8665808603489d3c6b5848d954608da970a8e4870014c6250
+size 353294

--- a/docs/literature/BPD_Literature_Review.pdf
+++ b/docs/literature/BPD_Literature_Review.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:27f6511b6bd8fab1552b4666c75eda652c33674b2477d21454a0bb44a0bf11af
+size 123334

--- a/docs/surveys/BPD_Survey_Problem_Solution_2025.pdf
+++ b/docs/surveys/BPD_Survey_Problem_Solution_2025.pdf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2aef87f4b591c2cb5d4d9317acbb9631f14e070cfddbae75116b3adb31736ef6
+size 408945


### PR DESCRIPTION
Adds four PDFs in review-friendly locations
Figma export: design/figma/exports/
UML diagram: design/diagrams/exports/
Literature review: docs/literature/
Survey: docs/surveys/
PDFs tracked via Git LFS